### PR TITLE
Fix error opening two consecutive jobs

### DIFF
--- a/app/adapters/job.js
+++ b/app/adapters/job.js
@@ -3,4 +3,8 @@ import ApplicationAdapter from './application';
 
 export default ApplicationAdapter.extend({
   host: config.stand,
+
+  shouldReloadRecord() {
+    return true;
+  }
 });

--- a/app/controllers/not-found.js
+++ b/app/controllers/not-found.js
@@ -1,6 +1,6 @@
 import Ember from 'ember';
 
-const { String: { pluralize, underscore } } = Ember;
+const { String: { pluralize } } = Ember;
 
 export default Ember.Controller.extend({
   queryParams: ['resource'],
@@ -10,4 +10,3 @@ export default Ember.Controller.extend({
     return resources;
   }),
 });
-

--- a/app/templates/job/show.hbs
+++ b/app/templates/job/show.hbs
@@ -1,4 +1,4 @@
 <div id="job-diagram-container-wrapper" class="container-fluid toggled">
   {{jobs/option-bar class="job-option-bar row" job=model.job}}
   {{jobs/job-container-diagram class="draw jobs-screen" id="job-container-diagram" workflow=model.job.workflow stepsLogs=stepsLogs steps=model.job.steps job=model.job operations=model.operations}}
- </div> <!-- class=container-->
+</div>


### PR DESCRIPTION
Ember was downloading all jobs on job#index but for some reason was unable to use them individually. This commit changes it and force ember to only download a job when the user wants to see it.

Fix #293