### PR TITLE
Fixes Map-Chart URL

### DIFF
--- a/app/initializers/visualizations.js
+++ b/app/initializers/visualizations.js
@@ -38,7 +38,7 @@ export function initialize(/* application */) {
        title: "Map",
        subtitle: "Geographic",
        description: "A representation, usually on a flat surface, as of the features of an area of the earth or a portion of the heavens, showing them in their respective forms, sizes, and relationships according to some.",
-       url: "visualization?name=map",
+       url: "visualization?name=map-chart",
        dataUrl: "/assets/data/visualizations/map-chart.json"
      },
      line: {


### PR DESCRIPTION
Changed URL from "?name=map" to "?name=map-chart", since Ember requires
hyphen separated component names