### PR TITLE
Firefox error fixed.

### DIFF
--- a/app/templates/components/workflows/option-bar.hbs
+++ b/app/templates/components/workflows/option-bar.hbs
@@ -1,4 +1,4 @@
-<div class="row">
+<div class="row" style="height: 10px">
   <div id="flashSuccess" class="alert alert-success" style="display:none">
     <span>{{t 'alert.save.workflow.success'}}</span>
   </div>
@@ -33,8 +33,7 @@
     </a>
   </div>
 </div>
-<div class="row">
-
+<div class="row" style="height: 10px;">
   <div class="col-xs-12  col-sm-12 col-md-12 col-lg-12 col-xl-12">
     <div class="cluster">
       <label> {{t 'forms.cluster.label'}}</label>


### PR DESCRIPTION
Lacking the attribute height, firefox assumes height to be 100%, for some reason. If any height is set, then the container will work the way it should (Chrome and Firefox). Display: grid is also presented as a solution, it works on FF, but breaks chrome. As its a urgent task, this works for now, will try to find a better solution.